### PR TITLE
Fixes README to include missing param

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ client.forex.historic_ticks
 
 client.crypto.list # list exchanges
 
-Polgygonio::Websocket::Client.new(api_key).subscribe("XQ.BTC-USD") do |event|
+Polygonio::Websocket::Client.new("crypto", api_key).subscribe("XQ.BTC-USD") do |event|
   pp "Incoming message"
   pp event
 end


### PR DESCRIPTION
I was running into an error when trying to run `Polygonio::Websocket::Client::new` and realized that the path needed to be passed as the first argument to the function.

```ruby
[4] pry(main)> Polygonio::Websocket::Client.new(api_key)
ArgumentError: wrong number of arguments (given 1, expected 2..3)
from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/polygonio-0.2.2/lib/polygonio/websocket/client.rb:124:in `initialize'
```

Which I was able to fix with:
```ruby
[5] pry(main)> Polygonio::Websocket::Client.new('stocks', api_key)
=> #<Polygonio::Websocket::Client:0x0000560d1ee69778 @api_key="****************", @opts={}, @url="wss://socket.polygon.io/stocks", @ws=nil>
```